### PR TITLE
Make `generator` return a generator expression

### DIFF
--- a/yail/core.py
+++ b/yail/core.py
@@ -34,14 +34,13 @@ def generator(it):
     Examples:
 
         >>> generator(range(5))  # doctest: +ELLIPSIS
-        <generator object generator at 0x...>
+        <generator object ...<genexpr> at 0x...>
 
         >>> list(generator(range(5)))
         [0, 1, 2, 3, 4]
     """
 
-    for each in it:
-        yield each
+    return (each for each in it)
 
 
 def empty():


### PR DESCRIPTION
Follow up on PR ( https://github.com/jakirkham/yail/pull/2 ). Use a generator expression for `generator` instead of having it be a function.
