### PR TITLE
Add `sliding_window_filled`

### DIFF
--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -20,6 +20,7 @@ from yail.core import (
     duplicate,
     indices,
     pad,
+    sliding_window_filled,
 )
 
 
@@ -125,6 +126,61 @@ class TestYail(unittest.TestCase):
         assert list(zip(range(3), padded)) == [(0, None),
                                                (1, None),
                                                (2, None)]
+
+
+    def test_sliding_window_filled(self):
+        assert list(sliding_window_filled(range(5), 1)) == [(0,),
+                                                            (1,),
+                                                            (2,),
+                                                            (3,),
+                                                            (4,)]
+
+        assert list(sliding_window_filled(range(5), 2)) == [(0, 1,),
+                                                            (1, 2,),
+                                                            (2, 3,),
+                                                            (3, 4,)]
+
+        assert list(sliding_window_filled(range(5), 3)) == [(0, 1, 2,),
+                                                            (1, 2, 3,),
+                                                            (2, 3, 4,)]
+
+        seq = list(sliding_window_filled(range(5), 1, pad_before=True, pad_after=True))
+        assert seq == [(0,),
+                       (1,),
+                       (2,),
+                       (3,),
+                       (4,)]
+
+        seq = list(sliding_window_filled(range(5), 2, pad_before=False, pad_after=True))
+        assert seq == [(0, 1,),
+                       (1, 2,),
+                       (2, 3,),
+                       (3, 4,),
+                       (4, None,)]
+
+        seq = list(sliding_window_filled(range(5), 2, pad_before=True, pad_after=False))
+        assert seq == [(None, 0,),
+                       (0, 1,),
+                       (1, 2,),
+                       (2, 3,),
+                       (3, 4,)]
+
+        seq = list(sliding_window_filled(range(5), 2, pad_before=True, pad_after=True))
+        assert seq == [(None, 0,),
+                       (0, 1,),
+                       (1, 2,),
+                       (2, 3,),
+                       (3, 4,),
+                       (4, None,)]
+
+        seq = list(sliding_window_filled(range(5), 3, pad_before=True, pad_after=True))
+        assert seq == [(None, None, 0),
+                       (None, 0, 1),
+                       (0, 1, 2),
+                       (1, 2, 3),
+                       (2, 3, 4),
+                       (3, 4, None),
+                       (4, None, None)]
 
 
     def tearDown(self):

--- a/yail/core.py
+++ b/yail/core.py
@@ -204,3 +204,65 @@ def pad(seq, before=0, after=0, fill=None):
         all_seqs.append(itertools.repeat(fill, after))
 
     return concat(all_seqs)
+
+
+def sliding_window_filled(seq,
+                          n,
+                          pad_before=False,
+                          pad_after=False,
+                          fillvalue=None):
+    """ A sliding window with optional padding on either end..
+
+        Args:
+            seq(iter):                 an iterator or something that can
+                                            be turned into an iterator
+
+            n(int):                         number of generators to create as
+                                            lagged
+
+            pad_before(bool):               whether to continue zipping along
+                                            the longest generator
+
+            pad_after(bool):               whether to continue zipping along
+                                            the longest generator
+
+            fillvalue:                      value to use to fill generators
+                                            shorter than the longest.
+
+        Returns:
+            generator object:               a generator object that will return
+                                            values from each iterator.
+
+        Examples:
+
+            >>> list(sliding_window_filled(range(5), 2))
+            [(0, 1), (1, 2), (2, 3), (3, 4)]
+
+            >>> list(sliding_window_filled(range(5), 2, pad_after=True))
+            [(0, 1), (1, 2), (2, 3), (3, 4), (4, None)]
+
+            >>> list(sliding_window_filled(range(5), 2, pad_before=True, pad_after=True))
+            [(None, 0), (0, 1), (1, 2), (2, 3), (3, 4), (4, None)]
+    """
+
+    if pad_before and pad_after:
+        seq = pad(
+            seq,
+            before=(n - 1),
+            after=(n - 1),
+            fill=fillvalue
+        )
+    elif pad_before:
+        seq = pad(
+            seq,
+            before=(n - 1),
+            fill=fillvalue
+        )
+    elif pad_after:
+        seq = pad(
+            seq,
+            after=(n - 1),
+            fill=fillvalue
+        )
+
+    return(sliding_window(n, seq))


### PR DESCRIPTION
Adds `sliding_window_filled` for providing an extension to [`toolz.sliding_window`](http://toolz.readthedocs.io/en/latest/api.html#toolz.itertoolz.sliding_window) with a constant boundary condition if desired.
