### PR TITLE
Add split

### DIFF
--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -18,6 +18,7 @@ from yail.core import (
     single,
     cycles,
     duplicate,
+    split,
     indices,
     pad,
     sliding_window_filled,
@@ -97,6 +98,37 @@ class TestYail(unittest.TestCase):
         assert list(duplicate([1, 2, 3], 2)) == [1, 1, 2, 2, 3, 3]
         assert list(duplicate([1, 2, 3], 3)) == [1, 1, 1, 2, 2, 2, 3, 3, 3]
 
+
+    def test_split(self):
+        l = []
+        assert list(map(tuple, split(0, l))) == [tuple(),
+                                                 tuple(),
+                                                 tuple()]
+
+        l = [10, 20, 30, 40, 50]
+        assert list(map(tuple, split(0, l))) == [tuple(),
+                                                 (10,),
+                                                 (20, 30, 40, 50)]
+
+        l = [10, 20, 30, 40, 50]
+        assert list(map(tuple, split(4, l))) == [(10, 20, 30, 40,),
+                                                 (50,),
+                                                 tuple()]
+
+        l = [10, 20, 30, 40, 50]
+        assert list(map(tuple, split(5, l))) == [(10, 20, 30, 40, 50),
+                                                 tuple(),
+                                                 tuple()]
+
+        l = [10, 20, 30, 40, 50]
+        assert list(map(tuple, split(2, l))) == [(10, 20),
+                                                 (30,),
+                                                 (40, 50)]
+
+        l = range(10, 60, 10)
+        assert list(map(tuple, split(2, l))) == [(10, 20),
+                                                 (30,),
+                                                 (40, 50)]
 
     def test_indices(self):
         assert list(indices(0)) == []

--- a/yail/core.py
+++ b/yail/core.py
@@ -140,6 +140,43 @@ def duplicate(seq, n=1):
     return concat(map(lambda _: itertools.repeat(_, n), seq))
 
 
+def split(n, seq):
+    """ Splits the sequence around element n.
+
+    Provides 3 ``iterable``s in return.
+
+    1. Everything before the ``n``-th value.
+    2. An ``iterable`` with just the ``n``-th value.
+    3. Everything after the ``n``-th value.
+
+    Args:
+
+         n(integral):                   Index to split the iterable at.
+         seq(iterable):                 The sequence to split.
+
+    Returns:
+
+         ``tuple`` of ``iterable``s:    Each portion of the iterable
+                                        around the index.
+
+    Examples:
+
+         >>> list(map(tuple, split(2, range(5))))
+         [(0, 1), (2,), (3, 4)]
+
+         >>> list(map(tuple, split(2, [10, 20, 30, 40, 50])))
+         [(10, 20), (30,), (40, 50)]
+    """
+
+    front, middle, back = itertools.tee(seq, 3)
+
+    front = itertools.islice(front, 0, n)
+    middle = itertools.islice(middle, n, n + 1)
+    back = itertools.islice(back, n + 1, None)
+
+    return front, middle, back
+
+
 def indices(*sizes):
     """ Iterates over a length/shape.
 


### PR DESCRIPTION
Adds `split` to divide an iterable into 3 portions based on a given index, `n`. They are as follows. All are returned as `iterable`s to make them easier to work with.
1. The portion before the `n`-th element.
2. The `n`-th element.
3. The portion following the `n`-th element.
