### PR TITLE
Require future

### DIFF
--- a/environment_dev.yml
+++ b/environment_dev.yml
@@ -12,4 +12,6 @@ dependencies:
   - Sphinx==1.4.5
   - cryptography==1.4
   - pyyaml==3.11
+
   - toolz==0.8.0
+  - future==0.15.2

--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,7 @@ with open("HISTORY.rst") as history_file:
     history = history_file.read()
 
 requirements = [
+    "future>=0.15.2",
     "toolz>=0.8.0",
 ]
 

--- a/yail/core.py
+++ b/yail/core.py
@@ -12,10 +12,13 @@ from toolz.itertoolz import (
     sliding_window,
 )
 
-from toolz.compatibility import (
+from builtins import (
     range,
     map,
     zip,
+)
+
+from future.moves.itertools import (
     zip_longest,
 )
 


### PR DESCRIPTION
Makes use of [future](http://python-future.org) for Python 2 compatibility within Python 3.
